### PR TITLE
Avoid MiM by downloading through https

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -10,8 +10,8 @@ module.exports = function () {
   var scalaJsVersion = '0.6.7';
   
   var bin = new BinWrapper({strip: 0})
-    .src('http://www.scala-js.org/files/scalajs_' + scalaVersion + '-' + scalaJsVersion + '.tgz', 'darwin')
-    .src('http://www.scala-js.org/files/scalajs_' + scalaVersion + '-' + scalaJsVersion + '.tgz', 'linux')
+    .src('https://www.scala-js.org/files/scalajs_' + scalaVersion + '-' + scalaJsVersion + '.tgz', 'darwin')
+    .src('https://www.scala-js.org/files/scalajs_' + scalaVersion + '-' + scalaJsVersion + '.tgz', 'linux')
     .dest(path.join(path.dirname(__dirname), 'vendor'));
 
   return bluebird.promisifyAll(bin);


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-scalajs-standalone-bin

### ⚙️ Description *

Resources where downloaded through insecure connection enabling an attacker to intercept communications and replacing with malicious data, downloaded files are intended for execution

### 💻 Technical Description *

Replace http url with https for downloading resources

### 🐛 Proof of Concept (PoC) *

Download is performed through insecure connection

### 🔥 Proof of Fix (PoF) *

After fix Secure conection is stablished for downloads

### 👍 User Acceptance Testing (UAT)

Resources can be downloaded normally

![ScalaJSOk](https://user-images.githubusercontent.com/7505980/93319256-552ae700-f818-11ea-87f7-a6a5830ee393.png)
